### PR TITLE
Add NullSec Linux security distribution

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -617,6 +617,11 @@ The Hackademic Challenges implement realistic scenarios with known vulnerabiliti
 
 - [OWASP Hackademic Challenges project](https://github.com/Hackademic/hackademic/)
 
+## NullSec Linux
+NullSec Linux is a security-focused distribution with 135+ pre-installed tools for penetration testing, digital forensics, cloud security auditing, and AI/ML adversarial research. Features 9 specialized editions and custom tools written in Rust, Go, Zig, and Python.
+
+- [NullSec Linux](https://github.com/bad-antics/nullsec-linux)
+
 ## Web Attack and Exploitation Distro (WAED)
 The Web Attack and Exploitation Distro (WAED) is a lightweight virtual machine based on Debian Distribution. WAED is pre-configured with various real-world vulnerable web applications in a sandboxed environment. It includes pentesting tools that aid in finding web application vulnerabilities. The main motivation behind this project is to provide a practical environment to learn about web application's vulnerabilities without the hassle of dealing with complex configurations. Currently, there are around 18 vulnerable applications installed in WAED.
 


### PR DESCRIPTION
## Summary
Add NullSec Linux to the list of security distributions/resources.

## Distribution Details
**NullSec Linux** - Security-focused Linux Distribution

- **Repository**: https://github.com/bad-antics/nullsec-linux
- **Website**: https://bad-antics.github.io
- **Base**: Debian 13 (Trixie)

## Key Features
- 🔧 135+ pre-installed security tools
- 🎯 9 specialized editions:
  - Standard (general pentesting)
  - Forensics (DFIR)
  - Cloud (AWS/Azure/GCP security)
  - AI/ML (adversarial ML research)
  - Automotive (vehicle security)
  - Hardware (IoT/embedded)
  - Mobile (Android/iOS)
  - Live (forensic boot)
  - Minimal (lightweight)

- 🦀 Modern tools in Rust, Go, Zig
- 📦 4 architecture support (AMD64, ARM64, RISC-V, Apple Silicon)

Looking for collaborators interested in security tool development!