### PR TITLE
Add Pentest Mindmap — interactive pentesting command reference

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -646,6 +646,7 @@ This pentester training platform/lab is full of machines (boxes) to hack on the 
 
 - [Hack The Box link](https://www.hackthebox.eu/)
 
+- [Pentest Mindmap](https://pentestmindmap.com/en) - Interactive mindmap with 11,600+ pentesting commands across 32 categories. Searchable with one-click copy.
 #### Vulnhub
 We all learn in different ways: in a group, by yourself, reading books, watching/listening to other people, making notes or things out for yourself. Learning the basics & understanding them is essential; this knowledge can be enforced by then putting it into practice.
 


### PR DESCRIPTION
Adding Pentest Mindmap — an interactive web-based mindmap with 11,600+ pentesting commands organized across 32 categories.

A searchable, visual reference tool for pentesters. Commands are organized in a D3.js interactive mindmap covering recon, web hacking, AD, privesc, cloud, post-exploitation, and 26 more categories. Each command includes a description.

Trilingual (EN/FR/ES). Free 7-day trial available.